### PR TITLE
Remove `plugin.name`

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,6 @@
 const { run } = require("react-snap");
 
 module.exports = {
-  name: 'netlify-plugin-prerender-spa',
   onPostBuild: async({
     constants,
     inputs


### PR DESCRIPTION
The `name` property on plugins has been removed, in favor of the one inside `manifest.yml`.